### PR TITLE
Add site description to config YAML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@
 # in the templates via {{ site.myvariable }}.
 title: "#include <C++>"
 author: IncludeCpp
-description: Minimal, responsive Jekyll theme for hackers.
+description: Inclusive, diverse community for developers interested in C++
 url: "http://includecpp.org" # the base hostname & protocol for your site, e.g. http://example.com
 lang: en
 timezone: UTC


### PR DESCRIPTION
The current site description describes the Jekyll theme (since that was the initial setting). Links in Discord, Slack, etc. all show the description under linked page titles, so it's best to ensure that the description is relevant to our community. 🙂 