### PR TITLE
Escape <C++> in twitter cards

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -81,7 +81,7 @@
 
 {% if site.twitter.username %}
   <meta name="twitter:site" content="@{{ site.twitter.username | replace: "@", "" }}">
-  <meta name="twitter:title" content="{{ page.title | default: site.title | markdownify | strip_html | strip_newlines | escape_once }}">
+  <meta name="twitter:title" content="{{ page.title | default: site.title | replace: '<C++>', '＜C++＞' | markdownify | strip_html | strip_newlines | escape_once }}">
   <meta name="twitter:description" content="{{ seo_description }}">
   <meta name="twitter:url" content="{{ canonical_url }}">
 


### PR DESCRIPTION
When displaying our name in twitter cards, the <C++> part is dropped because it is recognized as an html tag by "strip_html".
This PR replaces it in our name with other UTF 8 characters that look the same but don't behave as html tags.