### PR TITLE
Update C++ Language Resources under References

### DIFF
--- a/resources/references/index.md
+++ b/resources/references/index.md
@@ -22,6 +22,12 @@ title: References and Links
 * Bjarne Stroustrup's [The C++ Programming Language (4th Edition)](https://www.stroustrup.com/4th.html)
 * [cppreference](https://en.cppreference.com/w/)
     * Not a learning resource but the most reliable and complete reference for syntax, libraries, and more.
+* [Resources that help you delve into C++](https://lesleylai.info/en/delve_into_cpp/)
+    * List of resources compiled by [Lesley Lai](https://lesleylai.info/)
+* [SG20 Education and Recommended Videos for Teaching C++](https://www.cjdb.com.au/sg20-and-videos)
+    * List of resources compiled by [Christopher Di Bella](https://www.cjdb.com.au/)
+* [Learning C++: useful resources](https://aslynatilla.github.io/2021/01/25/learning-cpp.html)
+    * Blog with recommendations and reflections on learning C++ by [Antonio Natilla](https://aslynatilla.github.io/)
 
 ## Organisations
 


### PR DESCRIPTION
Added links to websites with resources from Lesley Lai, Christopher Di Bella, and Antonio Natilla

There have been some messages in the Discord about resources to learn C++, and these links have been posted in the meta-website channel as candidates for adding. I read you are in the process of restructuring this section of the website, so maybe it doesn't make sense to make this change right now. My thinking was to be able to link to a single page from the #include website directly. If I'm getting ahead of myself please let me know.

Any feedback is welcome.

Edit: adding screenshot of what the page looks like after the changes
![image](https://user-images.githubusercontent.com/6117986/106647062-bf0d1880-658e-11eb-98e2-68b830449bae.png)
