### PR TITLE
Add GitHub Action - Markdown link check

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,19 @@
+name: Check Markdown links
+
+on: 
+  push:
+    branches:
+    - master
+  schedule:
+  # runs every monday at 9 am
+  - cron: "0 9 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'


### PR DESCRIPTION
Hi, I saw @claremacrae  already made some progress on automated link checking, but I decided to give it a go.

I found https://github.com/gaurav-nelson/github-action-markdown-link-check which looked pretty nice.

I created an action that runs on push for master and scheduled every monday at 9 am by cron. I used `use-quiet-mode` to to only show errors in output and `use-verbose-mode` to show detailed HTTP status for checked links.

I tested it on my fork, and it seemed to work as expected.

To test the scheduled cron, you could change it to run every 5 minutes by changing the `cron` field to `"*/5 * * * *"`, I believe that's the minimum.

Ref: #28 