### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,4 +1,14 @@
 {
-  "aliveStatusCodes": [200, 400],
-  "timeout": "20s"
+  "replacementPatterns": [
+    {
+      "pattern": "^/",
+      "replacement": "https://www.includecpp.org/"
+    },
+    {
+      "pattern": "^{{site.baseurl}}",
+      "replacement": "https://www.includecpp.org/"
+    }
+  ],
+  "timeout": "20s",
+  "aliveStatusCodes": [200, 400]
 }

--- a/conferences/scholarships.md
+++ b/conferences/scholarships.md
@@ -74,7 +74,7 @@ The ideal candidate is someone who would truly benefit from coming to a conferen
 |-----------------:|----------------------------------------------------------------------------------:|:-------------:|
 |        **TOTAL** |                                                                                   |     **40**    |
 
-Unfortunately ACCU 2020 [was cancelled](https://conference.accu.org/news/202003121205_accu2020cancelled). We are working on recovering funds already spent on conference tickets and travel arrangements that will no longer be used or carrying them forward a future conference where possible.
+Unfortunately ACCU 2020 [was cancelled](https://accu.org/conf-news/2020/2020-03-12-accu2020cancelled). We are working on recovering funds already spent on conference tickets and travel arrangements that will no longer be used or carrying them forward a future conference where possible.
 
 ## Scholar Testimonials
 

--- a/resources/articles/index.md
+++ b/resources/articles/index.md
@@ -60,7 +60,6 @@ In addition to very specific resources on language, hiring, and so on we have fo
 
 * [Sarah Mei -- The Power in Agile](https://youtu.be/YL-6RCTywbc)
   * "Agile" is systemically sexist, racist, and ableist. Includes great quotes like "Unintentional exclusion becomes intentional when you don't fix it"
-* [Guest post: Scholarships for women speakers at PuppetConf:  The Ada Initiative](https://adainitiative.org/2014/01/guest-post-scholarships-for-women-speakers-at-puppetconf/)
 * [FlowCon - Programming Diversity:  ashe dryden](http://www.ashedryden.com/flowcon-programming-diversity)
 * [How To Create A More Diverse Tech Conference:  Continuous Delivery](http://continuousdelivery.com/2013/09/how-we-got-40-female-speakers-at-flowcon/)
 * [The Myth of Magical Futures — Kate Losse](http://www.katelosse.tv/latest/2014/9/12/magical-futures)
@@ -88,7 +87,7 @@ In addition to very specific resources on language, hiring, and so on we have fo
 
 ## Online abuse
 
-* [Jez Humble on Twitter:](https://twitter.com/jezhumble/status/584603746534981633) "If you are a victim of online harassment, check out Crash Override: [crashoverridenetwork.com](http://crashoverridenetwork.com)"
+* [Jez Humble on Twitter:](https://twitter.com/jezhumble/status/584603746534981633) "If you are a victim of online harassment, check out Crash Override: [crashoverridenetwork.com](http://www.crashoverridenetwork.com)"
 
 ## History of Computing
 

--- a/resources/domains/conferences.md
+++ b/resources/domains/conferences.md
@@ -43,7 +43,6 @@ Our overall advice is on the [Organising Conferences page](/conferences/organisi
 
 ### Codes of Conduct
 
-* [Code Of Conduct « PIPELINE](https://pipelineconf.info/about/code-of-conduct/)
 * [Conference anti-harassment/Policy - Geek Feminism Wiki - Wikia](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy)
 * [Code of Conduct - LeanAgileScotland](https://leanagile.scot/2018/code-of-conduct/)
 * [Yow Our Policies: YOW!](http://yowconference.com.au/policies/)
@@ -70,7 +69,7 @@ Our overall advice is on the [Organising Conferences page](/conferences/organisi
   * how over half the speakers at a ThoughtWorks technical conference were women
   * "2020 was not the first year we set a goal for equal representation. It was the first time that we exceeded it."
 * [Alex WL Chan's excellent site](https://alexwlchan.net/ideas-for-inclusive-events/short-version/) for conference organisers.
-* [After a Year of #MeToo Impacting the Hacker Community, We Still Have Far to Go The Road Less Traveled By](http://deviating.net/words/?p=821)
+* [After a Year of #MeToo Impacting the Hacker Community, We Still Have Far to Go The Road Less Traveled By](https://words.deviating.net/?p=821)
 	* excellent list of thing to do when preparing to run a conference
 * [User stories for organising conferences  · GitHub](https://gist.github.com/doismellburning/6ef44a51df271bca4782)
 * [Considerations for more diverse conferences - Emily Webber](http://emilywebber.co.uk/considerations-for-more-diverse-conferences/)

--- a/resources/language/index.md
+++ b/resources/language/index.md
@@ -128,7 +128,7 @@ Some behaviours are so common in response to diversity efforts that they have be
 Being inclusive doesn't mean allowing everything, especially intolerance and rudeness: this is the "Paradox of Tolerance".
 
 * [Paradox of tolerance - Wikipedia](https://en.wikipedia.org/wiki/Paradox_of_tolerance)
-* [The Paradox of Tolerance](https://bigthink.com/the-paradox-of-tolerance) - To tolerate or not to tolerate—that is the question.
+* [The Paradox of Tolerance](https://bigthink.com/articles/the-paradox-of-tolerance) - To tolerate or not to tolerate—that is the question.
 
 <!-- ### Sealioning -->
 


### PR DESCRIPTION
I removed https://pipelineconf.info/about/code-of-conduct/, couldn't find a replacement. Found another code of conduct based on it, https://senseconf.com/code-of-conduct, but I don't know if it's good enough to make the list, maybe it's worth checking out.

I also removed https://adainitiative.org/2014/01/guest-post-scholarships-for-women-speakers-at-puppetconf/, the ada initiative seems to have been shutdown, see https://adainitiative.org/2015/08/04/announcing-the-shutdown-of-the-ada-initiative/

I couldn't get the https://support.discord.com/ links to work, they are still a 403, but all the other links should be fixed by this PR.