### PR TITLE
Increase font size of level 4 headings

### DIFF
--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -88,6 +88,10 @@ body {
     border-bottom: 1px solid $border-color;
   }
 
+  h4 {
+    font-size: 0.8125em;
+  }
+
 	h1, h2, h3, h4, h5, h6 {
 		.header-link {
 			position: relative;


### PR DESCRIPTION
Ref: #38 

I haven't worked with minimal-mistakes before, so I might be way off here, but here are my findings:

Level 4 headings are defined in `_sass/minimal-mistakes/_base.scss` as follows:

```
h4 {
  font-size: $type-size-6;
}
```

With `$type-size-6: 0.75em !default; // ~12px` in `_sass/minimal-mistakes/_variables.scss`.

Since `$type-size-6` is being used for other things than page headers, we can't just change that variable directly.

The solution I found was to define the size in `_sass/minimal-mistakes/_page.scss` inside the `.page__content` block.

I decided to go for 0.8125em (13px), since I didn't want it to look too similar to the h3 header, which is 16px.

Not a huge difference, but I think it looks better.

Before:
![image](https://user-images.githubusercontent.com/47738833/136283058-6ac0b197-8657-4353-b7c4-69187dfa2cf8.png)

After:
![image](https://user-images.githubusercontent.com/47738833/136282983-3e219ce1-6400-4b4c-91df-a20ce0ac5fbc.png)

If this is not what you had in mind, feel free to tell me so. At least I've learned some things about how the website works, and I'm now able to run it locally on my machine :)