### PR TITLE
Update font-size for headers

### DIFF
--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -83,13 +83,30 @@ body {
 }
 
 .page__content {
+  h1 {
+    font-size: 2em;
+  }
+
   h2 {
+    font-size: 1.5em;
     padding-bottom: 0.5em;
     border-bottom: 1px solid $border-color;
   }
 
+  h3 {
+    font-size: 1.17em;
+  }
+
   h4 {
-    font-size: 0.8125em;
+    font-size: 1em;
+  }
+
+  h5 {
+    font-size: .83em;
+  }
+
+  h6 {
+    font-size: .67em;
   }
 
 	h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
I made a branch with some default font-size values for all the headers found here: https://www.w3schools.com/tags/tag_hn.asp
This will make the level 4 headers the same size as the text.
Let me know what you think, if you don't like it, we could just close this, or maybe tweak the values a bit.

Here are the changes for each header:
```
h1 1.563em -> 2em
h2 1.25em  -> 1.5em
h3 1em     -> 1.17em
h4 .8125em -> 1em
h5 0.75em  ->.83em
h6 0.75em  -> 0.67em
```