### PR TITLE
Re-enable quiet mode on link check and change timeout to 60s

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        use-quiet-mode: 'no'
+        use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -20,5 +20,5 @@
       "replacement": "https://www.includecpp.org"
     }
   ],
-  "timeout": "20s"
+  "timeout": "60s"
 }


### PR DESCRIPTION
This is to find out if the breaking link that times out succeeds with this timeout